### PR TITLE
Fix syntax error in registrations edit template

### DIFF
--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -25,6 +25,6 @@
     = f.submit t('update'), class: 'button is-primary'
 
 %p
-  = "#{t('.update')} #{link_to t(.cancel_my_account), registration_path(resource_name), data: {confirm: t('.are_you_sure')}, method: :delete}"
+  = link_to t('.cancel_my_account'), registration_path(resource_name), data: {confirm: t('.are_you_sure')}, method: :delete
 
 = link_to t('.back'), :back


### PR DESCRIPTION
Issue Fixed: There is a syntax error in Registrations edit  haml template

<img width="1030" alt="Screenshot 2021-06-10 at 12 04 52 am" src="https://user-images.githubusercontent.com/637558/121441084-02cebf00-c981-11eb-801d-783c3cb2ba4c.png">
 

## Proposed Changes
- Fix the syntax in error causing line 
